### PR TITLE
docs: fix audio sentence in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bluetooth Control Web UI (Raspberry Pi Zero 2 W · Debian 12)
 
-A small Flask + Bootstrap web app to scan, pair, trust, connect, disconnect, and forget Bluetooth devices — optimized for **audio** (A2DP/AVRCP via BlueZ + BlueALSA).  
+A small Flask + Bootstrap web app to scan, pair, trust, connect, disconnect, and forget Bluetooth devices — optimized for **audio** (A2DP/AVRCP via BlueZ + BlueALSA).
 Open it from any browser on your LAN.
 
 ---


### PR DESCRIPTION
## Summary
- join README description so audio statement reads on one line

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b5802d1b88322ad40933c49ad22ab