### PR TITLE
Use system Python in bt-web service

### DIFF
--- a/bt-web.service
+++ b/bt-web.service
@@ -7,9 +7,9 @@ Description=Bluetooth Web UI
 After=network.target bluetooth.target
 
 [Service]
-ExecStart=/opt/bt-web/venv/bin/python /opt/bt-web/app.py
+ExecStart=/usr/bin/python3 /opt/bt-web/app.py
 WorkingDirectory=/opt/bt-web
-Restart=always
+Restart=on-failure
 User=pi
 Environment=PYTHONUNBUFFERED=1
 Environment=PORT=8080


### PR DESCRIPTION
## Summary
- use /usr/bin/python3 in bt-web service to avoid virtualenv dependency
- match documentation by restarting on failure

## Testing
- `systemd-analyze verify bt-web.service`
- `python -m py_compile web-bt/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689b581aed38832287d6a04f25472b1a