### PR TITLE
Add test audio button for Bluetooth connections

### DIFF
--- a/web-bt/app.py
+++ b/web-bt/app.py
@@ -378,6 +378,16 @@ def api_forget():
     # Best-effort result; devices list will reflect reality
     return jsonify({"ok": True, "log": clean_for_js(txt)})
 
+@app.post("/api/test_audio")
+def api_test_audio():
+    """Play a short test sound to verify the audio path."""
+    wav = "/usr/share/sounds/alsa/Front_Center.wav"
+    try:
+        subprocess.run(["aplay", "-q", wav], check=True)
+        return jsonify({"ok": True, "log": ""})
+    except Exception as e:
+        return jsonify({"ok": False, "log": clean_for_js(str(e))}), 500
+
 @app.get("/")
 def index():
     return render_template("index.html")

--- a/web-bt/static/script.js
+++ b/web-bt/static/script.js
@@ -9,6 +9,7 @@ const statusArea   = document.getElementById('statusArea');
 const connectBtn   = document.getElementById('connectBtn');
 const disconnectBtn= document.getElementById('disconnectBtn');
 const forgetBtn    = document.getElementById('forgetBtn');
+const testAudioBtn = document.getElementById('testAudioBtn');
 const refreshBtn   = document.getElementById('refreshBtn');
 const clearLogBtn  = document.getElementById('clearLogBtn');
 const copyLogBtn   = document.getElementById('copyLogBtn');
@@ -46,7 +47,7 @@ function deviceStateBadge(d) {
 function renderStatus(info) {
   if (!info) {
     statusArea.innerHTML = '<span class="text-secondary">No device selected.</span>';
-    connectBtn.disabled = true; disconnectBtn.disabled = true; forgetBtn.disabled = true;
+    connectBtn.disabled = true; disconnectBtn.disabled = true; forgetBtn.disabled = true; testAudioBtn.disabled = true;
     return;
   }
   statusArea.innerHTML =
@@ -54,6 +55,7 @@ function renderStatus(info) {
   connectBtn.disabled    = info.connected || !selectedMac;
   disconnectBtn.disabled = !info.connected || !selectedMac;
   forgetBtn.disabled     = !selectedMac;
+  testAudioBtn.disabled  = !info.connected;
 }
 
 function renderList() {
@@ -197,6 +199,22 @@ forgetBtn.addEventListener('click', async () => {
   selectedMac = devices[0]?.mac || "";
   await refreshDeviceInfo();
   forgetBtn.disabled = false;
+});
+
+testAudioBtn.addEventListener('click', async () => {
+  testAudioBtn.disabled = true;
+  try {
+    const res = await fetch('/api/test_audio', { method: 'POST' });
+    const data = await res.json();
+    if (!data.ok) {
+      showLogRAW(data.log || "");
+      alert('Audio test failed');
+    }
+  } catch (e) {
+    showLogRAW(String(e));
+    alert('Audio test failed');
+  }
+  await refreshDeviceInfo();
 });
 
 refreshBtn.addEventListener('click', async () => {

--- a/web-bt/templates/index.html
+++ b/web-bt/templates/index.html
@@ -59,6 +59,7 @@
               <button class="btn btn-warning flex-fill" id="disconnectBtn" disabled>Disconnect</button>
               <button class="btn btn-danger flex-fill" id="forgetBtn" disabled>Forget</button>
             </div>
+            <button class="btn btn-info" id="testAudioBtn" disabled>Play Test Audio</button>
             <div class="small text-secondary">
               Connect will: <em>pair (while scanning)</em> → <em>stop scan</em> → <em>trust</em> → <em>connect</em>.
             </div>


### PR DESCRIPTION
## Summary
- Add "Play Test Audio" button in Actions panel to verify audio path
- Enable button only when a device is connected
- Implement `/api/test_audio` endpoint and include bundled test WAV
- Use system `Front_Center.wav` instead of bundled file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689be089a71883228e60e5e150227fd2