### PR TITLE
Organize app startup and webhook placement

### DIFF
--- a/web-bt/app.py
+++ b/web-bt/app.py
@@ -392,10 +392,6 @@ def api_test_audio():
 def index():
     return render_template("index.html")
 
-if __name__ == "__main__":
-    port = int(os.environ.get("PORT", "8080"))
-    app.run(host="0.0.0.0", port=port)
-
 @app.post("/github-webhook")
 def github_webhook():
     import hmac, hashlib, os


### PR DESCRIPTION
## Summary
- Remove duplicate `__main__` execution block
- Keep `github_webhook` route above the single app entry point

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c03619cf88322979d8ecff2247504