### PR TITLE
Handle scan start failure when bluetoothctl is missing

### DIFF
--- a/tests/test_scan_toggle.py
+++ b/tests/test_scan_toggle.py
@@ -1,0 +1,40 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+# Minimal Flask stub
+flask_stub = types.ModuleType("flask")
+
+class _Flask:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def route(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+    get = route
+    post = route
+
+flask_stub.Flask = _Flask
+flask_stub.jsonify = lambda *a, **k: {}
+flask_stub.request = None
+flask_stub.render_template = lambda *a, **k: None
+sys.modules.setdefault("flask", flask_stub)
+
+spec = importlib.util.spec_from_file_location(
+    "app", Path(__file__).resolve().parents[1] / "web-bt" / "app.py"
+)
+app = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app)
+
+
+def test_scan_on_failure_keeps_state_false(monkeypatch):
+    def boom():
+        raise FileNotFoundError("bluetoothctl")
+    monkeypatch.setattr(app, "_start_persistent_scan", boom)
+    app.SCAN_STATE["wanted"] = False
+    app.api_scan_on()
+    assert app.SCAN_STATE["wanted"] is False

--- a/web-bt/app.py
+++ b/web-bt/app.py
@@ -272,8 +272,12 @@ def bctl_connect_wait(mac, wait_s=8):
 # ------------------ API ------------------
 @app.post("/api/scan_on")
 def api_scan_on():
+    try:
+        _start_persistent_scan()
+    except Exception as e:
+        SCAN_STATE["wanted"] = False
+        return jsonify({"ok": False, "status": {}, "log": clean_for_js(str(e))}), 500
     SCAN_STATE["wanted"] = True
-    _start_persistent_scan()
     time.sleep(0.5)
     return jsonify({"ok": True, "status": adapter_status(), "log": ""})
 

--- a/web-bt/static/script.js
+++ b/web-bt/static/script.js
@@ -133,7 +133,12 @@ scanToggle.addEventListener('click', async () => {
   scanToggle.disabled = true;
   try {
     const turningOn = scanText.textContent.includes("On");
-    await fetch(turningOn ? '/api/scan_on' : '/api/scan_off', { method: 'POST' });
+    const res = await fetch(turningOn ? '/api/scan_on' : '/api/scan_off', { method: 'POST' });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      showLogRAW(data.log || 'Scan toggle failed');
+      alert('Scan toggle failed');
+    }
     await updateScanUI();
   } finally {
     scanToggle.disabled = false;


### PR DESCRIPTION
## Summary
- fail scan start gracefully if bluetoothctl is unavailable
- show scan toggle errors on the client
- add regression test for scan start failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c05cea9e88322ac4fc0d5d87bf0e8