### PR TITLE
Fix log sanitization to preserve ANSI escape codes

### DIFF
--- a/tests/test_clean_for_js.py
+++ b/tests/test_clean_for_js.py
@@ -1,0 +1,38 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+# Minimal Flask stub
+flask_stub = types.ModuleType("flask")
+
+class _Flask:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def route(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+    get = route
+    post = route
+
+flask_stub.Flask = _Flask
+flask_stub.jsonify = lambda *a, **k: None
+flask_stub.request = None
+flask_stub.render_template = lambda *a, **k: None
+sys.modules.setdefault("flask", flask_stub)
+
+spec = importlib.util.spec_from_file_location(
+    "app", Path(__file__).resolve().parents[1] / "web-bt" / "app.py"
+)
+app = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app)
+
+clean_for_js = app.clean_for_js
+
+
+def test_preserves_ansi_escape():
+    sample = "\x1b[31mRed\x1b[0m\n"
+    assert clean_for_js(sample) == sample

--- a/web-bt/app.py
+++ b/web-bt/app.py
@@ -30,8 +30,8 @@ ADAPTER_CACHE = {"mac": None, "ts": 0.0}
 
 # ------------------ Utilities ------------------
 def clean_for_js(text: str) -> str:
-    """Keep printable, plus newline and tab. (Client will render ANSI with ansi-to-html.)"""
-    return "".join(ch for ch in text if ch in ("\n", "\t") or ord(ch) >= 0x20)
+    """Keep printable plus ANSI escapes, newline and tab for client-side rendering."""
+    return "".join(ch for ch in text if ch in ("\n", "\t", "\x1b") or ord(ch) >= 0x20)
 
 def _get_adapter_mac(timeout=10):
     now = time.time()


### PR DESCRIPTION
## Summary
- Keep ESC characters in `clean_for_js` so ansi-to-html can render colored logs
- Add test ensuring `clean_for_js` preserves ANSI escape sequences

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e64fcf51083229260a00552943aca