### PR TITLE
Add GitHub webhook to trigger deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,30 @@ aplay -D bluealsa:DEV=<Speaker-MAC>,PROFILE=a2dp /usr/share/sounds/alsa/Front_Ce
 
 ---
 
+## 6) Auto-update via GitHub webhook
+
+The app can listen for GitHub webhooks and trigger a local script on each push.
+
+1. Create a webhook in your GitHub repository pointing to:
+
+   `http://<Host IP>:8080/github-webhook`
+
+2. Set a **secret** for the webhook and export it before starting the app:
+
+   ```bash
+   export GITHUB_WEBHOOK_SECRET="<your-secret>"
+   ```
+
+3. (Optional) Specify a script to run (defaults to `deploy.sh` in the project root):
+
+   ```bash
+   export GITHUB_WEBHOOK_SCRIPT="/path/to/your/script.sh"
+   ```
+
+On each push, the script executes in the background, allowing simple auto-deployments.
+
+---
+
 ## How it works (summary)
 
 - **Scan On** starts a persistent `bluetoothctl` session that keeps scanning.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+git pull --ff-only


### PR DESCRIPTION
## Summary
- add `/github-webhook` endpoint that runs a local script when GitHub push events arrive
- include default `deploy.sh` script and docs for configuring webhook

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e65db1fe483228fda00384bb81a15