### PR TITLE
Style MAC addresses as Bootstrap pills

### DIFF
--- a/web-bt/static/script.js
+++ b/web-bt/static/script.js
@@ -66,7 +66,7 @@ function renderList() {
     item.innerHTML = `
       <div>
         <div class="fw-semibold">${alias}</div>
-        <div class="text-secondary small mac">${d.mac}</div>
+        <div class="badge text-bg-secondary rounded-pill mac">${d.mac}</div>
       </div>
       <div>${deviceStateBadge(d)}</div>
     `;

--- a/web-bt/static/style.css
+++ b/web-bt/static/style.css
@@ -12,15 +12,15 @@
     padding: 0.5rem;
 }
 
-/* Ensure MAC address is readable when row is active */
+/* Ensure MAC address badge is readable when row is active */
 .list-group-item.active .mac {
-    color: #e5e7eb !important; /* light gray */
-    opacity: 0.95;
+    background-color: #adb5bd; /* lighter gray */
+    color: #212529;
 }
 
-/* Keep device name + MAC aligned nicely */
+/* Keep device name + MAC badge aligned nicely */
 .mac {
-    font-size: 0.8rem;
+    font-size: 0.75rem;
 }
 
 /* Scan status message */

--- a/web-bt/templates/index.html
+++ b/web-bt/templates/index.html
@@ -57,9 +57,6 @@
               <button class="btn btn-warning flex-fill" id="disconnectBtn" disabled>Disconnect</button>
               <button class="btn btn-danger flex-fill" id="forgetBtn" disabled>Forget</button>
             </div>
-            <div class="small text-secondary">
-              Connect will: <em>pair (while scanning)</em> → <em>stop scan</em> → <em>trust</em> → <em>connect</em>.
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Remove outdated connect instructions from the Actions card
- Show device MAC addresses as Bootstrap pill badges
- Adjust styles so MAC badges remain legible when selected

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e83fa2e4c832280e6c9bcfd14e64f