### PR TITLE
Show paired Bluetooth devices without scanning

### DIFF
--- a/tests/test_list_devices.py
+++ b/tests/test_list_devices.py
@@ -1,0 +1,42 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+# Minimal Flask stub
+flask_stub = types.ModuleType("flask")
+
+class _Flask:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def route(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+    get = route
+    post = route
+
+flask_stub.Flask = _Flask
+flask_stub.jsonify = lambda *a, **k: None
+flask_stub.request = None
+flask_stub.render_template = lambda *a, **k: None
+sys.modules.setdefault("flask", flask_stub)
+
+spec = importlib.util.spec_from_file_location(
+    "app", Path(__file__).resolve().parents[1] / "web-bt" / "app.py"
+)
+app = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app)
+
+
+def test_list_devices_includes_paired(monkeypatch):
+    def fake_run_bctl(cmds, timeout=30):
+        assert "devices" in cmds
+        assert "paired-devices" in cmds
+        return 0, "Device AA:BB:CC:DD:EE:FF MySpeaker\n", ""
+
+    monkeypatch.setattr(app, "run_bctl", fake_run_bctl)
+    devices = app.list_devices()
+    assert devices == [{"mac": "AA:BB:CC:DD:EE:FF", "name": "MySpeaker"}]

--- a/web-bt/app.py
+++ b/web-bt/app.py
@@ -84,13 +84,14 @@ def adapter_status():
     return st
 
 def list_devices():
-    rc, out, _ = run_bctl(["devices"])
-    devices = []
+    rc, out, _ = run_bctl(["devices", "paired-devices"])
+    found = {}
     for line in out.splitlines():
         m = DEVICE_LINE.match(line.strip())
         if m:
-            devices.append({"mac": m.group(1), "name": m.group(2)})
-    return devices
+            mac, name = m.group(1), m.group(2)
+            found.setdefault(mac, {"mac": mac, "name": name})
+    return list(found.values())
 
 def get_info(mac):
     rc, out, _ = run_bctl([f"info {mac}"])


### PR DESCRIPTION
## Summary
- include paired devices when listing, so previously paired hardware appears even if not currently scanning
- add test ensuring list_devices uses paired-devices

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e8ea177a083228613f3db03c4ab7d