### PR TITLE
Handle Bluetooth Class parsing for audio detection

### DIFF
--- a/tests/test_audio_detection.py
+++ b/tests/test_audio_detection.py
@@ -46,3 +46,8 @@ def test_returns_true_for_name_hint():
 def test_returns_false_without_hints():
     info = {"uuids": ["1234", "abcd"]}
     assert is_audio_capable(info, name_hint="GenericDevice") is False
+
+
+def test_returns_true_for_audio_cod_major_class():
+    info = {"class": "0x00240404"}
+    assert is_audio_capable(info) is True


### PR DESCRIPTION
## Summary
- parse `Class:` from `bluetoothctl info` output and expose it via API
- detect audio-capable devices using CoD major class
- add regression test for CoD-based audio detection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e96e1ae508322a6f68494a34514ad