### PR TITLE
Add Klipsch brand to audio name hints

### DIFF
--- a/tests/test_audio_detection.py
+++ b/tests/test_audio_detection.py
@@ -43,6 +43,11 @@ def test_returns_true_for_name_hint():
     assert is_audio_capable(info, name_hint="My SoundLink Device") is True
 
 
+def test_returns_true_for_klipsch_name_hint():
+    info = {"uuids": []}
+    assert is_audio_capable(info, name_hint="Klipsch Speaker") is True
+
+
 def test_returns_false_without_hints():
     info = {"uuids": ["1234", "abcd"]}
     assert is_audio_capable(info, name_hint="GenericDevice") is False

--- a/web-bt/app.py
+++ b/web-bt/app.py
@@ -19,8 +19,20 @@ AUDIO_UUID_HINTS = (
     "0000111e",  # Handsfree (HFP)
 )
 AUDIO_NAME_HINTS = (
-    "bose", "soundlink", "speaker", "headset", "headphone", "airpods",
-    "jbl", "sony", "anker", "marshall", "beats", "earbud", "soundcore"
+    "bose",
+    "soundlink",
+    "speaker",
+    "headset",
+    "headphone",
+    "airpods",
+    "jbl",
+    "sony",
+    "anker",
+    "marshall",
+    "beats",
+    "earbud",
+    "soundcore",
+    "klipsch",
 )
 
 # ------------------ Regex ------------------


### PR DESCRIPTION
## Summary
- include 'klipsch' in AUDIO_NAME_HINTS for audio device detection
- add regression test for Klipsch name hint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e9d0deae08322ae5cc7b90d3c5587