### PR TITLE
Handle random Bluetooth addresses with links to fixed identity

### DIFF
--- a/tests/test_identity_link.py
+++ b/tests/test_identity_link.py
@@ -1,0 +1,59 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+# Minimal Flask stub
+flask_stub = types.ModuleType("flask")
+
+class _Flask:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def route(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+    get = route
+    post = route
+
+flask_stub.Flask = _Flask
+flask_stub.jsonify = lambda *a, **k: k.get("data", a[0] if a else None)
+flask_stub.request = types.SimpleNamespace(args={})
+flask_stub.render_template = lambda *a, **k: None
+sys.modules.setdefault("flask", flask_stub)
+
+spec = importlib.util.spec_from_file_location(
+    "app", Path(__file__).resolve().parents[1] / "web-bt" / "app.py"
+)
+app = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app)
+
+
+def test_random_device_links_to_fixed(monkeypatch):
+    devices_output = (
+        "Device AA:AA:AA:AA:AA:01 (random) Foo\n"
+        "Device BB:BB:BB:BB:BB:01 Foo\n"
+    )
+
+    def fake_run_bctl(cmds, timeout=30):
+        if cmds == ["devices", "paired-devices"]:
+            return 0, devices_output, ""
+        if cmds == ["info AA:AA:AA:AA:AA:01"]:
+            return 0, "Identity Address: BB:BB:BB:BB:BB:01 (public)\nAlias: Foo\n", ""
+        if cmds == ["info BB:BB:BB:BB:BB:01"]:
+            return 0, "Alias: Foo\n", ""
+        return 0, "", ""
+
+    monkeypatch.setattr(app, "run_bctl", fake_run_bctl)
+
+    devices = app.list_devices()
+    macs = {d["mac"] for d in devices}
+    assert {
+        "AA:AA:AA:AA:AA:01",
+        "BB:BB:BB:BB:BB:01",
+    } == macs
+
+    info = app.get_info("AA:AA:AA:AA:AA:01")
+    assert info["identity"] == "BB:BB:BB:BB:BB:01"

--- a/tests/test_list_devices.py
+++ b/tests/test_list_devices.py
@@ -39,4 +39,4 @@ def test_list_devices_includes_paired(monkeypatch):
 
     monkeypatch.setattr(app, "run_bctl", fake_run_bctl)
     devices = app.list_devices()
-    assert devices == [{"mac": "AA:BB:CC:DD:EE:FF", "name": "MySpeaker"}]
+    assert devices == [{"mac": "AA:BB:CC:DD:EE:FF", "name": "MySpeaker", "type": None}]

--- a/web-bt/static/script.js
+++ b/web-bt/static/script.js
@@ -62,13 +62,16 @@ function renderList() {
 
   devices.forEach(d => {
     const alias = d.alias || d.name || "(unknown)";
+    const identityLink = d.identity && d.identity !== d.mac
+      ? `<a href="#" class="ms-2 small identity-link" data-mac="${d.identity}">→ ${d.identity}</a>`
+      : "";
     const item = document.createElement('button');
     item.type = "button";
     item.className = "list-group-item list-group-item-action d-flex justify-content-between align-items-center";
     item.innerHTML = `
       <div>
         <div class="fw-semibold">${alias}</div>
-        <div class="badge text-bg-secondary rounded-pill mac">${d.mac}</div>
+        <div class="badge text-bg-secondary rounded-pill mac">${d.mac}</div>${identityLink}
       </div>
       <div>${deviceStateBadge(d)}</div>
     `;
@@ -79,6 +82,17 @@ function renderList() {
       await refreshDeviceInfo();
     });
     deviceList.appendChild(item);
+
+    if (identityLink) {
+      const link = item.querySelector('.identity-link');
+      link.addEventListener('click', async (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        selectedMac = link.getAttribute('data-mac');
+        renderList();
+        await refreshDeviceInfo();
+      });
+    }
   });
 
   if (devices.length === 0) {


### PR DESCRIPTION
## Summary
- Parse optional address type tags when listing devices and expose each device's identity address
- Show a clickable link from random addresses to their fixed identity in the UI device list
- Add tests for identity address parsing and adjust existing list device test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ea12c83e4832289a2cedb4a503cd3