### PR TITLE
Log dropped non-audio devices in api_devices

### DIFF
--- a/tests/test_api_devices.py
+++ b/tests/test_api_devices.py
@@ -1,0 +1,59 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+# Minimal Flask stub for api_devices tests
+flask_stub = types.ModuleType("flask")
+
+class _Flask:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def route(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+    get = route
+    post = route
+
+flask_stub.Flask = _Flask
+flask_stub.jsonify = lambda obj=None, **k: obj
+flask_stub.request = types.SimpleNamespace(args={})
+flask_stub.render_template = lambda *a, **k: None
+sys.modules.setdefault("flask", flask_stub)
+
+spec = importlib.util.spec_from_file_location(
+    "app", Path(__file__).resolve().parents[1] / "web-bt" / "app.py"
+)
+app = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app)
+
+
+def test_api_devices_logs_dropped(monkeypatch, capsys):
+    monkeypatch.setattr(
+        app, "list_devices", lambda: [{"mac": "AA:BB:CC:DD:EE:FF", "name": "Thing"}]
+    )
+
+    def fake_get_info(mac):
+        return {
+            "alias": "Thing",
+            "class": "0x1234",
+            "paired": False,
+            "connected": False,
+        }
+
+    monkeypatch.setattr(app, "get_info", fake_get_info)
+    monkeypatch.setattr(app, "is_audio_capable", lambda info, name: False)
+
+    flask_stub.request.args = {"audio_only": "1"}
+    resp = app.api_devices()
+    assert resp == {
+        "devices": [],
+        "dropped": [{"mac": "AA:BB:CC:DD:EE:FF", "name": "Thing", "class": "0x1234"}],
+    }
+    out = capsys.readouterr().out
+    assert "AA:BB:CC:DD:EE:FF" in out
+    assert "Thing" in out
+    assert "0x1234" in out


### PR DESCRIPTION
## Summary
- compute `audio_ok` for each device and log filtered-out entries
- expose dropped device diagnostics in `/api/devices`
- test logging of dropped non-audio devices

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ea64a2460832281d8f4d8718d33da