### PR TITLE
Document creating service user

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,14 @@ sudo systemctl enable --now bluetooth
 sudo mkdir -p /opt/bt-web
 cd /opt
 sudo git clone https://github.com/<your-username>/<your-repo>.git bt-web
-sudo chown -R pi:pi /opt/bt-web
+```
+
+The service runs as a non-root user. Create a dedicated system account (e.g., `bt-web`)
+and ensure the app files are owned by it:
+
+```bash
+sudo adduser --system --group bt-web   # create user+group if they don't exist
+sudo chown -R bt-web:bt-web /opt/bt-web
 ```
 
 Your tree should look like:
@@ -78,6 +85,9 @@ Stop the app with `Ctrl+C` when done testing.
 
 ## 4) Run as a service (systemd)
 
+Ensure the service runs as the same non-root user that owns `/opt/bt-web`.
+Replace `bt-web` in the unit file if you used a different account.
+
 Create the service file:
 
 ```bash
@@ -94,8 +104,8 @@ ExecStart=/usr/bin/python3 /opt/bt-web/app.py
 Environment=PORT=8080
 Environment=PYTHONUNBUFFERED=1
 Restart=on-failure
-User=pi
-Group=pi
+User=bt-web
+Group=bt-web
 
 [Install]
 WantedBy=multi-user.target

--- a/bt-web.service
+++ b/bt-web.service
@@ -8,7 +8,9 @@ After=network.target bluetooth.target
 ExecStart=/usr/bin/python3 /opt/bt-web/app.py
 WorkingDirectory=/opt/bt-web
 Restart=on-failure
-User=pi
+# Run as a non-root user; replace 'bt-web' with the account that owns /opt/bt-web
+User=bt-web
+Group=bt-web
 Environment=PYTHONUNBUFFERED=1
 Environment=PORT=8080
 # Uncomment to enable GitHub webhook auto-deploy


### PR DESCRIPTION
## Summary
- use a dedicated `bt-web` system account instead of `pi`
- update systemd unit example to run under that user

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f3d4731c083229f2c1d6aa40c4d40