### PR TITLE
Clarify web-bt subdirectory paths in deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,19 @@ sudo adduser --system --group bt-web   # create user+group if they don't exist
 sudo chown -R bt-web:bt-web /opt/bt-web
 ```
 
-Your tree should look like:
+After cloning, the application code lives in the `web-bt` subdirectory:
 
 ```
 /opt/bt-web
-├── app.py
-├── templates/
-│   └── index.html
-└── static/
-    ├── script.js
-    └── style.css
+├── web-bt/
+│   ├── app.py
+│   ├── templates/
+│   │   └── index.html
+│   └── static/
+│       ├── script.js
+│       └── style.css
+├── bt-web.service
+└── deploy.sh
 ```
 
 ---
@@ -68,7 +71,7 @@ Your tree should look like:
 ## 3) Quick test (foreground)
 
 ```bash
-python3 /opt/bt-web/app.py
+python3 /opt/bt-web/web-bt/app.py
 ```
 
 Then in a browser on your network:
@@ -99,8 +102,8 @@ Wants=bluetooth.service network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=/opt/bt-web
-ExecStart=/usr/bin/python3 /opt/bt-web/app.py
+WorkingDirectory=/opt/bt-web/web-bt
+ExecStart=/usr/bin/python3 /opt/bt-web/web-bt/app.py
 Environment=PORT=8080
 Environment=PYTHONUNBUFFERED=1
 Restart=on-failure

--- a/bt-web.service
+++ b/bt-web.service
@@ -5,8 +5,8 @@ Description=Bluetooth Web UI
 After=network.target bluetooth.target
 
 [Service]
-ExecStart=/usr/bin/python3 /opt/bt-web/app.py
-WorkingDirectory=/opt/bt-web
+ExecStart=/usr/bin/python3 /opt/bt-web/web-bt/app.py
+WorkingDirectory=/opt/bt-web/web-bt
 Restart=on-failure
 # Run as a non-root user; replace 'bt-web' with the account that owns /opt/bt-web
 User=bt-web


### PR DESCRIPTION
## Summary
- Document that application files reside under `web-bt`
- Update quick-start and systemd examples to use `web-bt` paths
- Adjust systemd unit file to run `app.py` from `web-bt`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f5763289c8322b703b848b60b1459