### PR TITLE
Use built-in Front_Center audio sample for test

### DIFF
--- a/tests/test_api_test_audio.py
+++ b/tests/test_api_test_audio.py
@@ -1,0 +1,47 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+# Minimal Flask stub
+flask_stub = types.ModuleType("flask")
+
+class _Flask:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def route(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+    get = post = route
+
+flask_stub.Flask = _Flask
+flask_stub.jsonify = lambda obj=None, **k: obj
+flask_stub.request = types.SimpleNamespace(json={})
+flask_stub.render_template = lambda *a, **k: None
+sys.modules.setdefault("flask", flask_stub)
+
+spec = importlib.util.spec_from_file_location(
+    "app", Path(__file__).resolve().parents[1] / "web-bt" / "app.py",
+)
+app = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app)
+
+
+def test_api_test_audio_uses_aplay(monkeypatch):
+    called = {}
+
+    def fake_run(args, stdout=None, stderr=None, timeout=None):
+        called["args"] = args
+        class P:
+            returncode = 0
+            stdout = b"front center"
+        return P()
+
+    monkeypatch.setattr(app.subprocess, "run", fake_run)
+    resp = app.api_test_audio()
+    assert resp["ok"] is True
+    assert called["args"][0] == "aplay"
+    assert "/usr/share/sounds/alsa/Front_Center.wav" in called["args"]

--- a/web-bt/app.py
+++ b/web-bt/app.py
@@ -360,9 +360,10 @@ def api_disconnect():
 
 @app.post("/api/test_audio")
 def api_test_audio():
+    audio_file = "/usr/share/sounds/alsa/Front_Center.wav"
     try:
         p = subprocess.run(
-            ["speaker-test", "-t", "sine", "-f", "440", "-l", "1"],
+            ["aplay", audio_file],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             timeout=10,
@@ -370,7 +371,7 @@ def api_test_audio():
         txt = f"\x1b[1m== test-audio\x1b[0m\n{p.stdout.decode(errors='ignore')}"
         return jsonify({"ok": p.returncode == 0, "log": clean_for_js(txt)})
     except FileNotFoundError as e:
-        txt = f"speaker-test not found: {e}"
+        txt = f"aplay not found: {e}"
         return jsonify({"ok": False, "log": clean_for_js(txt)}), 500
     except subprocess.TimeoutExpired as e:
         txt = f"test audio timeout: {e}"


### PR DESCRIPTION
## Summary
- play the system Front_Center.wav using `aplay` for the `/api/test_audio` endpoint
- add unit test verifying the endpoint invokes `aplay`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a35e2fd3588322b67960fef10b2cdf