### PR TITLE
feat: make log box collapsible

### DIFF
--- a/web-bt/static/script.js
+++ b/web-bt/static/script.js
@@ -261,6 +261,7 @@ copyLogBtn?.addEventListener('click', async () => {
   }
 });
 
+
 // --- Init ---
 (async function init() {
   try {

--- a/web-bt/static/style.css
+++ b/web-bt/static/style.css
@@ -38,3 +38,14 @@
 .badge {
     margin-right: 0.25rem;
 }
+
+/* Toggle button text for log collapse */
+#collapseLogBtn .when-closed {
+    display: none;
+}
+#collapseLogBtn.collapsed .when-open {
+    display: none;
+}
+#collapseLogBtn.collapsed .when-closed {
+    display: inline;
+}

--- a/web-bt/templates/index.html
+++ b/web-bt/templates/index.html
@@ -72,10 +72,16 @@
             <div class="d-flex gap-2">
               <button class="btn btn-sm btn-outline-secondary" id="copyLogBtn" title="Copy log to clipboard">Copy</button>
               <button class="btn btn-sm btn-outline-secondary" id="clearLogBtn">Clear</button>
+              <button class="btn btn-sm btn-outline-secondary" id="collapseLogBtn" type="button" data-bs-toggle="collapse" data-bs-target="#logCollapse" aria-expanded="true" aria-controls="logCollapse">
+                <span class="when-open">Hide</span>
+                <span class="when-closed">Show</span>
+              </button>
             </div>
           </div>
-          <div class="card-body">
-            <pre id="logBox" class="mb-0"></pre>
+          <div id="logCollapse" class="collapse show">
+            <div class="card-body">
+              <pre id="logBox" class="mb-0"></pre>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- rely solely on Bootstrap's collapse component for the log section
- toggle button label switches via CSS instead of custom JavaScript

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a35e903788832293a56cad2405a963