### PR TITLE
Log app version in browser console

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-7f20fb6f2b0a8fece56a3c87ade9a38ffaedba8fd7ed19ef0a2fa8a0304fc28f
+aa568f6a14cc29565d73f744e0aec464155acb5faa1a686a7f6a8dbf5aaa2e85

--- a/web-bt/app.py
+++ b/web-bt/app.py
@@ -411,7 +411,13 @@ def github_webhook():
 
 @app.get("/")
 def index():
-    return render_template("index.html")
+    version = "unknown"
+    try:
+        with open(os.path.join(os.path.dirname(__file__), "..", "VERSION")) as f:
+            version = f.read().strip()
+    except Exception:
+        pass
+    return render_template("index.html", version=version)
 
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", "8080"))

--- a/web-bt/static/script.js
+++ b/web-bt/static/script.js
@@ -16,6 +16,9 @@ const audioOnlyChk = document.getElementById('audioOnly');
 const testAudioBtn = document.getElementById('testAudioBtn');
 
 // --- ANSI renderer (client-side) ---
+if (window.APP_VERSION) {
+  console.debug('App version:', window.APP_VERSION);
+}
 const ansi = new AnsiToHtml();          // from CDN in index.html
 let lastLogRaw = "";                    // plain text for "Copy" button
 

--- a/web-bt/templates/index.html
+++ b/web-bt/templates/index.html
@@ -92,6 +92,8 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <!-- ANSI → HTML renderer -->
   <script src="/static/ansi-to-html.min.js"></script>
+  <!-- App version -->
+  <script>window.APP_VERSION = "{{ version }}";</script>
   <!-- App script -->
   <script src="/static/script.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Expose current build version from server
- Inject version into HTML and log to browser console for debugging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a364ee14308322914f41fdc1a87485