### PR TITLE
Include deploy script output in webhook response

### DIFF
--- a/tests/test_webhook_output.py
+++ b/tests/test_webhook_output.py
@@ -1,0 +1,46 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+# Minimal Flask stub for webhook tests
+flask_stub = types.ModuleType("flask")
+
+class _Flask:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def route(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+    get = route
+    post = route
+
+flask_stub.Flask = _Flask
+flask_stub.jsonify = lambda obj=None, **k: obj
+flask_stub.request = types.SimpleNamespace(headers={}, data=b"")
+flask_stub.render_template = lambda *a, **k: None
+sys.modules.setdefault("flask", flask_stub)
+
+spec = importlib.util.spec_from_file_location(
+    "app", Path(__file__).resolve().parents[1] / "web-bt" / "app.py"
+)
+app = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app)
+
+def test_webhook_returns_script_output(monkeypatch):
+    def fake_run(cmd, *a, **k):
+        assert cmd == ["bash", app.DEFAULT_WEBHOOK_SCRIPT]
+        class Dummy:
+            returncode = 0
+            stdout = "deploy ok\n"
+            stderr = ""
+        return Dummy()
+    monkeypatch.setattr(app.subprocess, "run", fake_run)
+    req = types.SimpleNamespace(headers={"X-GitHub-Event": "push"}, data=b"")
+    monkeypatch.setattr(app, "request", req)
+    resp, code = app.github_webhook()
+    assert code == 200
+    assert resp == {"ok": True, "stdout": "deploy ok\n", "stderr": ""}

--- a/web-bt/app.py
+++ b/web-bt/app.py
@@ -404,7 +404,16 @@ def github_webhook():
     if request.headers.get("X-GitHub-Event") == "push":
         script = os.environ.get("GITHUB_WEBHOOK_SCRIPT", DEFAULT_WEBHOOK_SCRIPT)
         try:
-            subprocess.Popen(["bash", script])
+            result = subprocess.run(
+                ["bash", script], capture_output=True, text=True
+            )
+            payload = {
+                "ok": result.returncode == 0,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+            code = 200 if result.returncode == 0 else 500
+            return jsonify(payload), code
         except Exception as exc:
             return jsonify({"ok": False, "error": str(exc)}), 500
     return jsonify({"ok": True})


### PR DESCRIPTION
## Summary
- capture `deploy.sh` output and return it from `/github-webhook`
- add unit test verifying webhook response contains script output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a36a3918e483229ca4f22049c971e7