### PR TITLE
Support device-specific audio tests

### DIFF
--- a/web-bt/static/script.js
+++ b/web-bt/static/script.js
@@ -219,7 +219,11 @@ forgetBtn.addEventListener('click', async () => {
 testAudioBtn.addEventListener('click', async () => {
   testAudioBtn.disabled = true;
   try {
-    const res = await fetch('/api/test_audio', { method: 'POST' });
+    const res = await fetch('/api/test_audio', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mac: selectedMac })
+    });
     const data = await res.json();
     showLogRAW(data.log || "");
     if (!data.ok) alert('Test audio failed');


### PR DESCRIPTION
## Summary
- let `/api/test_audio` accept a device MAC from JSON or `TEST_AUDIO_MAC`
- build `aplay` command targeting the device via bluealsa
- have web UI send the selected device MAC for audio tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3778182608322a66508951e567bf3