### PR TITLE
Add spinner to scanning indicator

### DIFF
--- a/web-bt/static/script.js
+++ b/web-bt/static/script.js
@@ -135,7 +135,9 @@ async function updateScanUI() {
   const running = !!js.running;
   const on = js.wanted || st.discovering || running;
   scanText.textContent = on ? "Scan Off" : "Scan On";
-  scanMsg.textContent = on ? "Scanning… (continuous)" : "Idle";
+  scanMsg.innerHTML = on
+    ? '<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Scanning…'
+    : 'Idle';
   if (on && !polling) {
     polling = setInterval(fetchDevices, 2500);
   } else if (!on && polling) {


### PR DESCRIPTION
## Summary
- show spinner while scanning and drop `(continuous)` label

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a37c949d74832287f01e2b6ea75794