### PR TITLE
Default log box to collapsed

### DIFF
--- a/web-bt/templates/index.html
+++ b/web-bt/templates/index.html
@@ -72,13 +72,13 @@
             <div class="d-flex gap-2">
               <button class="btn btn-sm btn-outline-secondary" id="copyLogBtn" title="Copy log to clipboard">Copy</button>
               <button class="btn btn-sm btn-outline-secondary" id="clearLogBtn">Clear</button>
-              <button class="btn btn-sm btn-outline-secondary" id="collapseLogBtn" type="button" data-bs-toggle="collapse" data-bs-target="#logCollapse" aria-expanded="true" aria-controls="logCollapse">
+              <button class="btn btn-sm btn-outline-secondary collapsed" id="collapseLogBtn" type="button" data-bs-toggle="collapse" data-bs-target="#logCollapse" aria-expanded="false" aria-controls="logCollapse">
                 <span class="when-open">Hide</span>
                 <span class="when-closed">Show</span>
               </button>
             </div>
           </div>
-          <div id="logCollapse" class="collapse show">
+          <div id="logCollapse" class="collapse">
             <div class="card-body">
               <pre id="logBox" class="mb-0"></pre>
             </div>


### PR DESCRIPTION
## Summary
- Collapse the log panel by default so logs are hidden until expanded

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a37d8f3da48322934e2ef53724acfa