### PR TITLE
Improve refresh button feedback

### DIFF
--- a/web-bt/static/script.js
+++ b/web-bt/static/script.js
@@ -250,8 +250,13 @@ testAudioBtn.addEventListener('click', async () => {
 });
 
 refreshBtn.addEventListener('click', async () => {
-  await fetchDevices();
-  await refreshDeviceInfo();
+  refreshBtn.disabled = true;
+  try {
+    await fetchDevices();
+    await refreshDeviceInfo();
+  } finally {
+    refreshBtn.disabled = false;
+  }
 });
 
 audioOnlyChk.addEventListener('change', async () => {

--- a/web-bt/templates/index.html
+++ b/web-bt/templates/index.html
@@ -22,7 +22,7 @@
           <input class="form-check-input" type="checkbox" role="switch" id="audioOnly" checked>
           <label class="form-check-label" for="audioOnly">Audio only</label>
         </div>
-        <button id="refreshBtn" class="btn btn-outline-secondary">Refresh</button>
+        <button id="refreshBtn" class="btn btn-outline-secondary" type="button">Refresh</button>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Prevent Refresh control from acting as a form submit button.
- Disable Refresh button during device list reload to signal activity.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a48cd5ef5c8322a6aad876476520f3