### PR TITLE
fix: pull from origin in deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -5,7 +5,7 @@ set -e
 cd "$(dirname "$0")"
 
 # Update repo
-git pull --ff-only
+git pull --ff-only origin main
 
 # Print the current version
 echo "Deploying version $(cat VERSION)"


### PR DESCRIPTION
## Summary
- avoid upstream branch errors by pulling from origin main in deploy script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a49439dfc483229eea68aae5a9d782