### PR TITLE
Handle bluetoothctl scan [CHG] lines

### DIFF
--- a/web-bt/app.py
+++ b/web-bt/app.py
@@ -170,7 +170,11 @@ def wait_info(mac, key, want=True, tries=12, delay=0.5):
 
 def _scan_reader(pipe):
     for line in pipe:
-        m = DEVICE_LINE.match(line.strip())
+        # bluetoothctl prefixes scan lines with markers like "[NEW]" or
+        # "[CHG]". Using ``search`` instead of ``match`` lets us extract the
+        # MAC address regardless of any leading tag so RSSI updates still bump
+        # the availability timestamp for known devices.
+        m = DEVICE_LINE.search(line)
         if not m:
             continue
         mac = m.group(1)


### PR DESCRIPTION
## Summary
- Update scan reader to capture device MACs in lines prefixed with tags like `[CHG]` or `[NEW]`
- Ensures RSSI updates bump the availability timestamp for known devices

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4965b91448322bb4a57841b93587c