### PR TITLE
Prompt for GitHub webhook secret during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,18 +195,20 @@ The app can listen for GitHub webhooks and trigger a local script on each push.
 
    `http://<Host IP>:8080/github-webhook`
 
-2. Set a **secret** for the webhook and export it before starting the app:
+2. Generate a secret by hashing a passphrase (SHA-256). The installer will
+   prompt for the passphrase and print the resulting hash. Use that hash in the
+   GitHub webhook settings or compute it manually:
 
    ```bash
-   export GITHUB_WEBHOOK_SECRET="<your-secret>"
+   printf '%s' 'your-passphrase' | sha256sum | cut -d' ' -f1
    ```
 
-   If the app runs as a systemd service, add the secret to the unit file instead:
+   If the app runs as a systemd service, add the hash to the unit file instead:
 
    ```ini
    # /etc/systemd/system/bt-web.service
    [Service]
-   Environment=GITHUB_WEBHOOK_SECRET=<your-secret>
+   Environment=GITHUB_WEBHOOK_SECRET=<your-hash>
    ```
 
    Then reload and restart:

--- a/bt-web.service
+++ b/bt-web.service
@@ -13,8 +13,10 @@ User=bt-web
 Group=bt-web
 Environment=PYTHONUNBUFFERED=1
 Environment=PORT=8080
-# Uncomment to enable GitHub webhook auto-deploy
-# Environment=GITHUB_WEBHOOK_SECRET=your-secret
+# Uncomment to enable GitHub webhook auto-deploy. Create a passphrase and hash it
+# (SHA-256) with:
+#   printf '%s' 'your-passphrase' | sha256sum | cut -d' ' -f1
+# Environment=GITHUB_WEBHOOK_SECRET=your-hash
 
 [Install]
 WantedBy=multi-user.target

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,22 @@ REPO_URL=${REPO_URL:-https://github.com/Muppet1856/BluetoothWebsite.git}
 DEST=/opt/bt-web
 SERVICE=/etc/systemd/system/bt-web.service
 
+# Prompt for optional GitHub webhook passphrase and hash it
+WEBHOOK_SECRET_HASH=""
+read -s -p "Enter GitHub webhook passphrase (leave blank to skip): " WEBHOOK_PASS
+echo
+if [[ -n "$WEBHOOK_PASS" ]]; then
+  read -s -p "Confirm GitHub webhook passphrase: " WEBHOOK_PASS_CONFIRM
+  echo
+  if [[ "$WEBHOOK_PASS" != "$WEBHOOK_PASS_CONFIRM" ]]; then
+    echo "Error: passphrases do not match" >&2
+    exit 1
+  fi
+  WEBHOOK_SECRET_HASH=$(printf '%s' "$WEBHOOK_PASS" | sha256sum | cut -d' ' -f1)
+  unset WEBHOOK_PASS WEBHOOK_PASS_CONFIRM
+  echo "Hashed webhook secret: $WEBHOOK_SECRET_HASH"
+fi
+
 apt update
 apt full-upgrade -y
 apt install -y bluetooth bluez bluez-tools bluez-alsa-utils alsa-utils python3-flask git
@@ -35,6 +51,9 @@ fi
 chown -R bt-web:bt-web "$DEST"
 
 cp "$DEST/bt-web.service" "$SERVICE"
+if [[ -n "$WEBHOOK_SECRET_HASH" ]]; then
+  sed -i "s|# Environment=GITHUB_WEBHOOK_SECRET=your-hash|Environment=GITHUB_WEBHOOK_SECRET=$WEBHOOK_SECRET_HASH|" "$SERVICE"
+fi
 systemctl daemon-reload
 systemctl enable --now bt-web
 


### PR DESCRIPTION
## Summary
- Document hashing a passphrase to create a GitHub webhook secret
- Prompt for a passphrase in the installer, hash it, and inject the hash into the systemd unit
- Clarify service unit comments with SHA-256 hash instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c0b31bf08322841cd86f308bf6f5