### PR TITLE
Add web-based Wi-Fi access point controls

### DIFF
--- a/web-bt/templates/index.html
+++ b/web-bt/templates/index.html
@@ -63,6 +63,31 @@
       </div>
     </div>
 
+    <!-- Row: Wi-Fi configuration -->
+    <div class="row g-3 mt-1">
+      <div class="col-12">
+        <div class="card shadow-sm">
+          <div class="card-header"><strong>Wi-Fi</strong></div>
+          <div class="card-body d-grid gap-3">
+            <div>
+              <label for="apSsid" class="form-label">Access Point SSID</label>
+              <div class="input-group">
+                <input id="apSsid" class="form-control" type="text" placeholder="AP SSID">
+                <button id="apSsidBtn" class="btn btn-primary" type="button">Set</button>
+              </div>
+            </div>
+            <div>
+              <div class="d-flex justify-content-between align-items-center mb-2">
+                <label class="form-label mb-0">Client Networks</label>
+                <button id="scanWifiBtn" class="btn btn-outline-secondary btn-sm" type="button">Scan</button>
+              </div>
+              <ul id="wifiList" class="list-group" style="max-height:12rem; overflow:auto;"></ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Row 2: Full-width Log -->
     <div class="row g-3 mt-1">
       <div class="col-12">

--- a/web-bt/wifi.py
+++ b/web-bt/wifi.py
@@ -1,0 +1,76 @@
+import os
+import subprocess
+from typing import List
+
+AP_CONF = "/etc/hostapd/hostapd.conf"
+AP_INTERFACE = "wlan0"
+
+
+def _hostname() -> str:
+    return os.uname().nodename
+
+
+def read_ap_ssid() -> str:
+    try:
+        with open(AP_CONF) as f:
+            for line in f:
+                if line.startswith("ssid="):
+                    return line.strip().split("=", 1)[1]
+    except Exception:
+        pass
+    return _hostname()
+
+
+def set_ap_ssid(ssid: str) -> None:
+    lines: List[str] = []
+    try:
+        with open(AP_CONF) as f:
+            for line in f:
+                if line.startswith("ssid="):
+                    lines.append(f"ssid={ssid}\n")
+                else:
+                    lines.append(line)
+    except FileNotFoundError:
+        lines = [
+            f"interface={AP_INTERFACE}\n",
+            "driver=nl80211\n",
+            f"ssid={ssid}\n",
+            "hw_mode=g\n",
+            "channel=1\n",
+            "auth_algs=1\n",
+            "ignore_broadcast_ssid=0\n",
+        ]
+    with open(AP_CONF, "w") as f:
+        f.writelines(lines)
+    try:
+        subprocess.run(["sudo", "systemctl", "restart", "hostapd"], check=False)
+    except Exception:
+        pass
+
+
+def list_client_networks() -> List[str]:
+    try:
+        p = subprocess.run(
+            ["nmcli", "-t", "-f", "SSID", "device", "wifi", "list"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+        nets = [line.strip() for line in p.stdout.splitlines() if line.strip()]
+    except Exception:
+        nets = []
+    ap_ssid = read_ap_ssid()
+    return [n for n in nets if n != ap_ssid]
+
+
+def connect_client(ssid: str) -> None:
+    try:
+        subprocess.run(
+            ["nmcli", "device", "wifi", "connect", ssid],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
- add wifi management helper to configure hostapd and connect to client networks
- expose `/api/ap` and `/api/wifi` endpoints for SSID updates and scanning
- expand UI and scripts with access point and client network controls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6324270708322a7a959f6eb975d9e