### PR TITLE
Allow webhook deploy script to use branch from webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,8 @@ The app can listen for GitHub webhooks and trigger a local script on each push.
    export GITHUB_WEBHOOK_SCRIPT="/path/to/your/script.sh"
    ```
 
-On each push, the script executes in the background, allowing simple auto-deployments.
+On each push, the script executes in the background with the branch name as its
+first argument, allowing simple auto-deployments.
 
 ---
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,8 +6,11 @@ echo "Running as $(whoami)"
 cd "$(dirname "$0")"
 
 # Update repo
-echo "Updating repository..."
-git pull --ff-only origin main
+BRANCH="${1:-main}"
+echo "Updating repository on branch $BRANCH..."
+git fetch origin "$BRANCH"
+git checkout "$BRANCH" || git checkout -b "$BRANCH" "origin/$BRANCH"
+git pull --ff-only origin "$BRANCH"
 
 # Print the current version
 echo "Deploying version $(cat VERSION)"


### PR DESCRIPTION
## Summary
- Teach deploy.sh to pull the branch named by the webhook
- Parse the branch from push events and pass it to the script
- Document branch argument and adjust tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6eb3218988322affd9cee9258bfb2