### PR TITLE
Add app version display to web UI

### DIFF
--- a/web-bt/static/script.js
+++ b/web-bt/static/script.js
@@ -18,10 +18,12 @@ const apSsid = document.getElementById('apSsid');
 const apSsidBtn = document.getElementById('apSsidBtn');
 const scanWifiBtn = document.getElementById('scanWifiBtn');
 const wifiList = document.getElementById('wifiList');
+const versionEl  = document.getElementById('version');
 
 // --- ANSI renderer (client-side) ---
 if (window.APP_VERSION) {
   console.debug('App version:', window.APP_VERSION);
+  if (versionEl) versionEl.textContent = window.APP_VERSION.slice(0, 7);
 }
 const ansi = new AnsiToHtml();          // from CDN in index.html
 let lastLogRaw = "";                    // plain text for "Copy" button

--- a/web-bt/templates/index.html
+++ b/web-bt/templates/index.html
@@ -13,7 +13,7 @@
   <div class="container py-4">
     <!-- Top controls -->
     <div class="d-flex align-items-center justify-content-between mb-3">
-      <h1 class="h4 mb-0">Bluetooth Controller</h1>
+      <h1 class="h4 mb-0">Bluetooth Controller <small id="version" class="text-secondary ms-2"></small></h1>
       <div class="d-flex gap-2">
         <button id="scanToggle" class="btn btn-primary">
           <span class="me-2" aria-hidden="true">🔎</span><span id="scanText">Scan On</span>


### PR DESCRIPTION
## Summary
- Show the app version in the page header of the Bluetooth Controller UI
- Populate the version label using `window.APP_VERSION` from `script.js`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f91ef2348322b3b06cb2ded25d82