### PR TITLE
Handle missing Wi-Fi interface

### DIFF
--- a/tests/test_wifi_client_access.py
+++ b/tests/test_wifi_client_access.py
@@ -51,8 +51,13 @@ def test_api_ap_set(monkeypatch):
 
 
 def test_api_wifi_list(monkeypatch):
-    monkeypatch.setattr(app, "list_client_networks", lambda: ["a", "b"])
-    assert app.api_wifi_list() == {"networks": ["a", "b"]}
+    monkeypatch.setattr(app, "list_client_networks", lambda: (["a", "b"], True))
+    assert app.api_wifi_list() == {"networks": ["a", "b"], "has_wifi": True}
+
+
+def test_api_wifi_list_no_iface(monkeypatch):
+    monkeypatch.setattr(app, "list_client_networks", lambda: ([], False))
+    assert app.api_wifi_list() == {"networks": [], "has_wifi": False}
 
 
 def test_api_wifi_connect(monkeypatch):

--- a/web-bt/app.py
+++ b/web-bt/app.py
@@ -508,8 +508,8 @@ def api_ap_set():
 
 @app.get("/api/wifi")
 def api_wifi_list():
-    nets = list_client_networks()
-    return jsonify({"networks": nets})
+    nets, has_iface = list_client_networks()
+    return jsonify({"networks": nets, "has_wifi": has_iface})
 
 @app.post("/api/wifi")
 def api_wifi_connect():

--- a/web-bt/static/script.js
+++ b/web-bt/static/script.js
@@ -287,7 +287,12 @@ async function scanWifi(){
     const res = await fetch('/api/wifi');
     const data = await res.json();
     const nets = data.networks || [];
-    if (nets.length === 0){
+    if (data.has_wifi === false) {
+      const li=document.createElement('li');
+      li.className='list-group-item text-danger';
+      li.textContent='No Wi-Fi interface detected';
+      wifiList.appendChild(li);
+    } else if (nets.length === 0){
       const li=document.createElement('li');
       li.className='list-group-item text-secondary';
       li.textContent='No networks';

--- a/web-bt/wifi.py
+++ b/web-bt/wifi.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from typing import List
+from typing import List, Tuple
 
 AP_CONF = "/etc/hostapd/hostapd.conf"
 AP_INTERFACE = "wlan0"
@@ -48,7 +48,8 @@ def set_ap_ssid(ssid: str) -> None:
         pass
 
 
-def list_client_networks() -> List[str]:
+def list_client_networks() -> Tuple[List[str], bool]:
+    """Return available client SSIDs and whether a Wi-Fi interface exists."""
     try:
         p = subprocess.run(
             ["nmcli", "-t", "-f", "SSID", "device", "wifi", "list"],
@@ -57,11 +58,13 @@ def list_client_networks() -> List[str]:
             text=True,
             check=False,
         )
+        has_iface = "No Wi-Fi device" not in (p.stderr or "")
         nets = [line.strip() for line in p.stdout.splitlines() if line.strip()]
     except Exception:
+        has_iface = False
         nets = []
     ap_ssid = read_ap_ssid()
-    return [n for n in nets if n != ap_ssid]
+    return [n for n in nets if n != ap_ssid], has_iface
 
 
 def connect_client(ssid: str) -> None:


### PR DESCRIPTION
## Summary
- detect absence of Wi-Fi hardware and expose it via `/api/wifi`
- show a clear message in the UI when no Wi-Fi interface is present
- cover Wi-Fi API's new behaviour with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6ff0158248322a489316bd33e1b77