### PR TITLE
Group IP info by interface

### DIFF
--- a/tests/test_wifi_client_access.py
+++ b/tests/test_wifi_client_access.py
@@ -78,12 +78,20 @@ def test_api_wifi_info(monkeypatch):
     monkeypatch.setattr(
         app,
         "get_client_ip_info",
-        lambda: {"ip": "1.2.3.4", "mask": "255.255.255.0", "gateway": "1.2.3.1"},
+        lambda: {
+            "wlan0": {
+                "ip": "1.2.3.4",
+                "mask": "255.255.255.0",
+                "gateway": "1.2.3.1",
+            }
+        },
     )
     assert app.api_wifi_info() == {
-        "ip": "1.2.3.4",
-        "mask": "255.255.255.0",
-        "gateway": "1.2.3.1",
+        "wlan0": {
+            "ip": "1.2.3.4",
+            "mask": "255.255.255.0",
+            "gateway": "1.2.3.1",
+        }
     }
 
 

--- a/web-bt/static/script.js
+++ b/web-bt/static/script.js
@@ -285,8 +285,16 @@ async function updateWifiInfo(){
   try{
     const res = await fetch('/api/wifi_info');
     const data = await res.json();
-    if (data.ip){
-      wifiInfo.textContent = `IP: ${data.ip}/${data.mask || '?'}, GW: ${data.gateway || '?'}`;
+    const ifaces = Object.keys(data || {});
+    if (ifaces.length){
+      const parts = [];
+      ifaces.forEach(iface => {
+        const info = data[iface] || {};
+        if (info.ip){
+          parts.push(`${iface}: ${info.ip}/${info.mask || '?'}, GW: ${info.gateway || '?'}`);
+        }
+      });
+      wifiInfo.textContent = parts.join(' | ') || 'No IP address';
     } else {
       wifiInfo.textContent = 'No IP address';
     }

--- a/web-bt/wifi.py
+++ b/web-bt/wifi.py
@@ -80,8 +80,8 @@ def connect_client(ssid: str) -> None:
 
 
 def get_client_ip_info() -> dict:
-    """Return IP address, subnet mask and gateway for the Wi-Fi interface."""
-    info = {"ip": None, "mask": None, "gateway": None}
+    """Return IPv4 info grouped by interface name."""
+    info = {AP_INTERFACE: {"ip": None, "mask": None, "gateway": None}}
     try:
         p = subprocess.run(
             ["ip", "-4", "addr", "show", AP_INTERFACE],
@@ -95,15 +95,15 @@ def get_client_ip_info() -> dict:
             if line.startswith("inet "):
                 addr = line.split()[1]  # e.g. 192.168.1.5/24
                 ip, prefix = addr.split("/")
-                info["ip"] = ip
+                info[AP_INTERFACE]["ip"] = ip
                 try:
                     import ipaddress
 
-                    info["mask"] = str(
+                    info[AP_INTERFACE]["mask"] = str(
                         ipaddress.IPv4Network("0.0.0.0/" + prefix).netmask
                     )
                 except Exception:
-                    info["mask"] = None
+                    info[AP_INTERFACE]["mask"] = None
                 break
     except Exception:
         pass
@@ -119,7 +119,7 @@ def get_client_ip_info() -> dict:
         for line in p.stdout.splitlines():
             parts = line.strip().split()
             if parts and parts[0] == "default" and "via" in parts:
-                info["gateway"] = parts[parts.index("via") + 1]
+                info[AP_INTERFACE]["gateway"] = parts[parts.index("via") + 1]
                 break
     except Exception:
         pass


### PR DESCRIPTION
## Summary
- group client IP info by interface name
- display grouped IPs in wifi status UI
- adjust wifi API tests for new structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b70999aebc8322ab6386ad81cccee6